### PR TITLE
Be explicit about bareword filehandles:

### DIFF
--- a/lib/Term/Table/Util.pm
+++ b/lib/Term/Table/Util.pm
@@ -13,7 +13,7 @@ sub DEFAULT_SIZE() { 80 }
 
 my $IO;
 BEGIN {
-    open($IO, '>&', STDOUT) or die "Could not clone STDOUT";
+    open($IO, '>&', *STDOUT) or die "Could not clone STDOUT";
 }
 
 sub try(&) {

--- a/t/honor_env_in_non_tty.t
+++ b/t/honor_env_in_non_tty.t
@@ -5,8 +5,8 @@ use warnings;
 BEGIN {
     my $out = "";
     local *STDOUT;
-    open(STDOUT, '>', \$out) or die "Could not open a temp STDOUT: $!";
-    ok(!-t STDOUT, "STDOUT is not a term");
+    open(*STDOUT, '>', \$out) or die "Could not open a temp STDOUT: $!";
+    ok(!-t *STDOUT, "STDOUT is not a term");
 
     require Term::Table::Util;
     Term::Table::Util->import(qw/term_size USE_TERM_READKEY USE_TERM_SIZE_ANY/);


### PR DESCRIPTION
While using `STDOUT` is understood by the Perl interpreter as a clear filehandle, it isn't understood as such by any code that tries to parse the same function calls, like `Test::MockFile` that overrides `open` but the prototypes used cannot really mimick the perl parsing.

Using `*STDOUT` is understood by both perl and any code that uses overrides `open`.