### PR TITLE
require minimum version of Test2::Tools::Tiny

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+    - t/honor_env_in_non_tty.t requires Test2::Tools::Tiny >= 1.30297;
+      use Test::More if not available
+
 0.022     2024-08-06 11:40:22-07:00 America/Los_Angeles
 
     - Some initial support for non-ASCII systems

--- a/t/honor_env_in_non_tty.t
+++ b/t/honor_env_in_non_tty.t
@@ -2,9 +2,8 @@ use strict;
 use warnings;
 
 BEGIN {
-    if (eval { require Test2::Tools::Tiny }) {
+    if (eval 'use  Test2::Tools::Tiny 1.302097; 1; ' ) {
         print "# Using Test2::Tools::Tiny\n";
-        Test2::Tools::Tiny->import();
     }
     elsif (eval { require Test::More; Test::More->can('done_testing') ? 1 : 0 }) {
         print "# Using Test::More " . Test::More->VERSION . "\n";


### PR DESCRIPTION
This test fails when run with Test2::Tools::Tiny (Test::Simple) < 1.302097.

Perl 5.26 shipped with Test::Simple 1.302073, so this test will fail unless Test::Simple is upgraded.

Howver, Test::Simple >= 1.302200 depends on Text::Table.

Upgrading to the current Test::Simple (1.302204 at the time of this writing) will fail, as Text::Table must first be installed, wihch requires t/honor_env_in_non_tty.t to pass under the existing Test::Simple, which fails, and is the reason we're here in the first place.

t/honor_env_in_non_tty.t happily passes using Test::More from Test::Simple 1.302073, shipped with Perl 5.26.3, as well as that in Test::Simple 1.302096.  Test2::Tools::Tiny may be used starting with Test::Simple 1.302097.

This test now prefers Test::More prior to
Test::Simple 1.302097, and Test2::Tools::Tiny thereafter.