### PR TITLE
When in Perl core, diagnostic message on stderr not needed

### DIFF
--- a/t/honor_env_in_non_tty.t
+++ b/t/honor_env_in_non_tty.t
@@ -3,7 +3,12 @@ use warnings;
 
 BEGIN {
     if (eval { require Test2::Tools::Tiny; Test2::Tools::Tiny->VERSION(1.302097); 1 }) {
-        print STDERR "# Using Test2::Tools::Tiny " . Test2::Tools::Tiny->VERSION . "\n";
+        if (!$ENV{PERL_CORE}) {
+            print STDERR "# Using Test2::Tools::Tiny " . Test2::Tools::Tiny->VERSION . "\n";
+        }
+        else {
+            print "# Using Test2::Tools::Tiny\n";
+        }
         Test2::Tools::Tiny->import;
     }
     elsif (eval { require Test::More; Test::More->can('done_testing') ? 1 : 0 }) {


### PR DESCRIPTION
This message appears to have been added in e8196e90854 as a diagnostic aid for https://github.com/exodist/Term-Table/issues/8.  It prints to STDERR; similarly positioned messages in the other test files simply print to STDERR.

For the Perl 5 core distribution, I'm developing an application whose user can opt to throw away the voluminous output of `./Configure`, `make`, etc.  That will reduce the amount of output flowing on a user's terminal to statements going to STDERR.  It would be nice to also eliminate STDERR messages which are not clearly pertinent to the core distribution.  This patch suppresses printing to STDERR when envvar `PERL_CORE` is set to a true value.  Please review.