### PR TITLE
get proper terminal size if writing to a pipe, e.g. Test::Harness

### DIFF
--- a/lib/Term/Table/Util.pm
+++ b/lib/Term/Table/Util.pm
@@ -28,7 +28,7 @@ my ($tsa) = try { require Term::Size::Any; Term::Size::Any->import('chars') };
 my ($trk) = try { require Term::ReadKey };
 $trk &&= Term::ReadKey->can('GetTerminalSize');
 
-if (!-t $IO) {
+if (!-t $IO && !-p $IO) {
     *USE_TERM_READKEY  = sub() { 0 };
     *USE_TERM_SIZE_ANY = sub() { 0 };
     *term_size         = sub {


### PR DESCRIPTION
It's been driving me crazy that `prove -l t/mytest.t` doesn't use the terminal size to calculate the table size. I dug in and found the place where it was skipping getting the size.

I'm open to how this could be tested in a platform-agnostic way -- I thought about piping stdin and stdout through `cat`, or forking a subprocess that simply echoed everything it received. I'm not sure what's possible that's MSWin32-friendly.